### PR TITLE
Prevent "Unknown app_id" crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,9 @@ The proxy requires the following open-source packages:
 Installation
 ------------
 
-On a Mac, it's easiest to use [brew](http://mxcl.github.com/homebrew/):
+This fork does not maintain the brew installation.
 
-      brew install ios-webkit-debug-proxy
-      
-On Linux or Mac:
+On Linux:
 
       sudo apt-get install \
           autoconf automake \
@@ -39,11 +37,22 @@ On Linux or Mac:
           libplist-dev libplist++-dev \
           usbmuxd \
           libimobiledevice-dev
-
+On Mac, it's easiest to use homebrew for the dependencies:
+      brew install \
+        autoconf automake \
+        libusb libplist \
+        usbmuxd \
+      brew install --HEAD ideviceinstaller
       ./autogen.sh
       ./configure           # for debug symbols, append 'CFLAGS=-g -O0'
       make
       sudo make install
+
+Personally, my dependencies at thie time of this writing is:
+    ideviceinstaller HEAD
+    libplist 1.12
+    libusb 1.0.19
+    usbmuxd 1.0.10
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ On Linux:
           usbmuxd \
           libimobiledevice-dev
 On Mac, it's easiest to use homebrew for the dependencies:
+
       brew install \
         autoconf automake \
         libusb libplist \
@@ -48,7 +49,8 @@ On Mac, it's easiest to use homebrew for the dependencies:
       make
       sudo make install
 
-Personally, my dependencies at thie time of this writing is:
+Personally, my dependencies at thie time of this writing (Febuary 11, 2015) is:
+
     ideviceinstaller HEAD
     libplist 1.12
     libusb 1.0.19

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ On Mac, it's easiest to use homebrew for the dependencies:
       make
       sudo make install
 
-Personally, my dependencies at thie time of this writing (Febuary 11, 2015) is:
+Personally, my dependencies at the time of this writing (Febuary 11, 2015) is:
 
     ideviceinstaller HEAD
     libplist 1.12

--- a/include/rpc.h
+++ b/include/rpc.h
@@ -107,6 +107,9 @@ struct rpc_struct {
             const char *app_id, const char *dest_id,
             const char *data, size_t length);
 
+    rpc_status (*on_applicationUpdated)(rpc_t self,
+            const char *app_id, const char *dest_id);
+
     // For internal use only:
     rpc_status (*on_error)(rpc_t self, const char *format, ...);
 };

--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -1305,7 +1305,8 @@ rpc_status iwdp_on_applicationSentListing(rpc_t rpc,
     return RPC_ERROR;  // Inspector closed?
   }
   if (!ht_get_value(iwi->app_id_to_true, app_id)) {
-    return self->on_error(self, "Unknown app_id %s", app_id);
+    // ignore update for a tab which is not in the hash map
+    return RPC_SUCCESS;
   }
   ht_t ipage_ht = iwi->page_num_to_ipage;
   iwdp_ipage_t *ipages = (iwdp_ipage_t *)ht_values(ipage_ht);

--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -1271,6 +1271,9 @@ rpc_status iwdp_on_applicationDisconnected(rpc_t rpc, const rpc_app_t app) {
 rpc_status iwdp_on_reportConnectedApplicationList(rpc_t rpc, const rpc_app_t *apps) {
   iwdp_iwi_t iwi = (iwdp_iwi_t)rpc->state;
   ht_t app_id_ht = iwi->app_id_to_true;
+  if (*apps == NULL) {
+    return RPC_SUCCESS;
+  }
 
   // remove old apps
   char **old_app_ids = (char **)ht_keys(app_id_ht);

--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -1381,6 +1381,17 @@ rpc_status iwdp_on_applicationSentData(rpc_t rpc,
       data, length);
 }
 
+rpc_status iwdp_on_applicationUpdated(rpc_t rpc,
+    const char *app_id, const char *dest_id) {
+  fprintf(stderr, "Removing app_id: %s, adding: %s\n", app_id, dest_id);
+  rpc_status result = iwdp_remove_app_id(rpc, app_id);
+  if (result) {
+    // Error removing app_id
+    return result;
+  }
+  return iwdp_add_app_id(rpc, dest_id);
+}
+
 //
 // STRUCTS
 //
@@ -1600,6 +1611,7 @@ iwdp_iwi_t iwdp_iwi_new(bool is_sim, bool *is_debug) {
   rpc->on_applicationDisconnected = iwdp_on_applicationDisconnected;
   rpc->on_applicationSentListing = iwdp_on_applicationSentListing;
   rpc->on_applicationSentData = iwdp_on_applicationSentData;
+  rpc->on_applicationUpdated = iwdp_on_applicationUpdated;
   rpc->send_plist = iwdp_send_plist;
   rpc->state = iwi;
   iwi->rpc = rpc;

--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -1088,9 +1088,6 @@ ws_status iwdp_on_frame(ws_t ws,
       iwdp_ipage_t ipage = iws->ipage;
       if (!ipage) {
         // someone stole our page?
-        /*
-         * Removing this due to segfault when we do not remove com.apple.mobile safari
-         * 
         iwdp_ipage_t p = (iws->page_num ? (iwdp_ipage_t)ht_get_value(
             iwi->page_num_to_ipage, HT_KEY(iws->page_num)) : NULL);
         char *s;
@@ -1102,9 +1099,6 @@ ws_status iwdp_on_frame(ws_t ws,
         ws->on_error(ws, "%s", s);
         ws_status ret = ws->send_close(ws, CLOSE_GOING_AWAY, s);
         free(s);
-        return ret;
-        */
-        ws_status ret = ws->send_close(ws, CLOSE_GOING_AWAY, "stolen page?");
         return ret;
       }
       rpc_t rpc = iwi->rpc;
@@ -1285,7 +1279,7 @@ rpc_status iwdp_on_reportConnectedApplicationList(rpc_t rpc, const rpc_app_t *ap
     const rpc_app_t *a;
     for (a = apps; *a && strcmp((*a)->app_id, *oa); a++) {
     }
-    if (!*a && strcmp(*oa, "com.apple.mobilesafari")) {
+    if (!*a) {
       iwdp_remove_app_id(rpc, *oa);
     }
   }

--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -1389,7 +1389,6 @@ rpc_status iwdp_on_applicationSentData(rpc_t rpc,
 
 rpc_status iwdp_on_applicationUpdated(rpc_t rpc,
     const char *app_id, const char *dest_id) {
-  fprintf(stderr, "Removing app_id: %s, adding: %s\n", app_id, dest_id);
   rpc_status result = iwdp_remove_app_id(rpc, app_id);
   if (result) {
     // Error removing app_id

--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -1088,6 +1088,9 @@ ws_status iwdp_on_frame(ws_t ws,
       iwdp_ipage_t ipage = iws->ipage;
       if (!ipage) {
         // someone stole our page?
+        /*
+         * Removing this due to segfault when we do not remove com.apple.mobile safari
+         * 
         iwdp_ipage_t p = (iws->page_num ? (iwdp_ipage_t)ht_get_value(
             iwi->page_num_to_ipage, HT_KEY(iws->page_num)) : NULL);
         char *s;
@@ -1099,6 +1102,9 @@ ws_status iwdp_on_frame(ws_t ws,
         ws->on_error(ws, "%s", s);
         ws_status ret = ws->send_close(ws, CLOSE_GOING_AWAY, s);
         free(s);
+        return ret;
+        */
+        ws_status ret = ws->send_close(ws, CLOSE_GOING_AWAY, "stolen page?");
         return ret;
       }
       rpc_t rpc = iwi->rpc;
@@ -1279,7 +1285,7 @@ rpc_status iwdp_on_reportConnectedApplicationList(rpc_t rpc, const rpc_app_t *ap
     const rpc_app_t *a;
     for (a = apps; *a && strcmp((*a)->app_id, *oa); a++) {
     }
-    if (!*a) {
+    if (!*a && strcmp(*oa, "com.apple.mobilesafari")) {
       iwdp_remove_app_id(rpc, *oa);
     }
   }

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -436,17 +436,34 @@ _rpc_applicationUpdated: <dict>
 <key>WIRApplicationIdentifierKey</key>
 <string>PID:536</string>
 </dict>
+
+OR
+
+<key>WIRApplicationBundleIdentifierKey</key>
+<string>com.apple.mobilesafari</string>
+<key>WIRApplicationNameKey</key>
+<string>Safari</string>
+<key>WIRIsApplicationProxyKey</key>
+<false/>
+<key>WIRIsApplicationActiveKey</key>
+<integer>0</integer>
+<key>WIRApplicationIdentifierKey</key>
+<string>PID:730</string>
 */
 rpc_status rpc_recv_applicationUpdated(rpc_t self, const plist_t args) {
   char *app_id = NULL;
   char *dest_id = NULL;
   rpc_status ret;
-  if (!rpc_dict_get_required_string(args, "WIRHostApplicationIdentifierKey",
-        &dest_id) &&
-      !rpc_dict_get_required_string(args, "WIRApplicationIdentifierKey",
-        &app_id) &&
-      !self->on_applicationUpdated(self,
-        app_id, dest_id)) {
+  if (!rpc_dict_get_required_string(args, "WIRHostApplicationIdentifierKey", &app_id)) {
+    if (!rpc_dict_get_required_string(args, "WIRApplicationIdentifierKey", &dest_id) &&
+      !self->on_applicationUpdated(self, app_id, dest_id)) {
+      ret = RPC_SUCCESS;
+    } else {
+      ret = RPC_ERROR;
+    }
+  } else if (!rpc_dict_get_required_string(args, "WIRApplicationNameKey", &app_id) &&
+             !rpc_dict_get_required_string(args, "WIRApplicationIdentifierKey", &dest_id) &&
+             !self->on_applicationUpdated(self, app_id, dest_id)) {
     ret = RPC_SUCCESS;
   } else {
     ret = RPC_ERROR;

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -421,6 +421,42 @@ rpc_status rpc_recv_applicationSentData(rpc_t self, const plist_t args) {
   return ret;
 }
 
+/*
+_rpc_applicationUpdated: <dict>
+<key>WIRApplicationBundleIdentifierKey</key>
+<string>com.apple.WebKit.WebContent</string>
+<key>WIRHostApplicationIdentifierKey</key>
+<string>PID:409</string>
+<key>WIRApplicationNameKey</key>
+<string></string>
+<key>WIRIsApplicationProxyKey</key>
+<true/>
+<key>WIRIsApplicationActiveKey</key>
+<integer>0</integer>
+<key>WIRApplicationIdentifierKey</key>
+<string>PID:536</string>
+</dict>
+*/
+rpc_status rpc_recv_applicationUpdated(rpc_t self, const plist_t args) {
+  char *app_id = NULL;
+  char *dest_id = NULL;
+  size_t length = 0;
+  rpc_status ret;
+  if (!rpc_dict_get_required_string(args, "WIRHostApplicationIdentifierKey",
+        &app_id) &&
+      !rpc_dict_get_required_data(args, "WIRApplicationIdentifierKey",
+        &dest_id, &length) &&
+      !self->on_applicationUpdated(self,
+        app_id, dest_id)) {
+    ret = RPC_SUCCESS;
+  } else {
+    ret = RPC_ERROR;
+  }
+  free(app_id);
+  free(dest_id);
+  return ret;
+}
+
 rpc_status rpc_recv_msg(rpc_t self, const char *selector, const plist_t args) {
   if (!selector) {
     return RPC_ERROR;
@@ -447,6 +483,10 @@ rpc_status rpc_recv_msg(rpc_t self, const char *selector, const plist_t args) {
     }
   } else if (!strcmp(selector, "_rpc_applicationSentData:")) {
     if (!rpc_recv_applicationSentData(self, args)) {
+      return RPC_SUCCESS;
+    }
+  } else if (!strcmp(selector, "_rpc_applicationUpdated:")) {
+    if (!rpc_recv_applicationUpdated(self, args)) {
       return RPC_SUCCESS;
     }
   }

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -440,12 +440,11 @@ _rpc_applicationUpdated: <dict>
 rpc_status rpc_recv_applicationUpdated(rpc_t self, const plist_t args) {
   char *app_id = NULL;
   char *dest_id = NULL;
-  size_t length = 0;
   rpc_status ret;
   if (!rpc_dict_get_required_string(args, "WIRHostApplicationIdentifierKey",
+        &dest_id) &&
+      !rpc_dict_get_required_string(args, "WIRApplicationIdentifierKey",
         &app_id) &&
-      !rpc_dict_get_required_data(args, "WIRApplicationIdentifierKey",
-        &dest_id, &length) &&
       !self->on_applicationUpdated(self,
         app_id, dest_id)) {
     ret = RPC_SUCCESS;


### PR DESCRIPTION
applicationSentListing is invoked when tab is changed. Sometimes there can be situation when the tab's app id is not in the hash table
It can occur when Safari was in background when proxy was launched or Safari goes into background and comes back again (SafariLauncher).
When such situation occur just ignore the update and don't crash the proxy
