### PR TITLE
Included _rpc_on_applicationUpdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,9 @@ The proxy requires the following open-source packages:
 Installation
 ------------
 
-On a Mac, it's easiest to use [brew](http://mxcl.github.com/homebrew/):
+This fork does not maintain the brew installation.
 
-      brew install ios-webkit-debug-proxy
-      
-On Linux or Mac:
+On Linux:
 
       sudo apt-get install \
           autoconf automake \
@@ -39,11 +37,24 @@ On Linux or Mac:
           libplist-dev libplist++-dev \
           usbmuxd \
           libimobiledevice-dev
+On Mac, it's easiest to use homebrew for the dependencies:
 
+      brew install \
+        autoconf automake \
+        libusb libplist \
+        usbmuxd \
+      brew install --HEAD ideviceinstaller
       ./autogen.sh
       ./configure           # for debug symbols, append 'CFLAGS=-g -O0'
       make
       sudo make install
+
+Personally, my dependencies at the time of this writing (Febuary 11, 2015) is:
+
+    ideviceinstaller HEAD
+    libplist 1.12
+    libusb 1.0.19
+    usbmuxd 1.0.10
 
 Usage
 -----

--- a/include/rpc.h
+++ b/include/rpc.h
@@ -107,6 +107,9 @@ struct rpc_struct {
             const char *app_id, const char *dest_id,
             const char *data, size_t length);
 
+    rpc_status (*on_applicationUpdated)(rpc_t self,
+            const char *app_id, const char *dest_id);
+
     // For internal use only:
     rpc_status (*on_error)(rpc_t self, const char *format, ...);
 };

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -421,6 +421,58 @@ rpc_status rpc_recv_applicationSentData(rpc_t self, const plist_t args) {
   return ret;
 }
 
+/*
+_rpc_applicationUpdated: <dict>
+<key>WIRApplicationBundleIdentifierKey</key>
+<string>com.apple.WebKit.WebContent</string>
+<key>WIRHostApplicationIdentifierKey</key>
+<string>PID:409</string>
+<key>WIRApplicationNameKey</key>
+<string></string>
+<key>WIRIsApplicationProxyKey</key>
+<true/>
+<key>WIRIsApplicationActiveKey</key>
+<integer>0</integer>
+<key>WIRApplicationIdentifierKey</key>
+<string>PID:536</string>
+</dict>
+
+OR
+
+<key>WIRApplicationBundleIdentifierKey</key>
+<string>com.apple.mobilesafari</string>
+<key>WIRApplicationNameKey</key>
+<string>Safari</string>
+<key>WIRIsApplicationProxyKey</key>
+<false/>
+<key>WIRIsApplicationActiveKey</key>
+<integer>0</integer>
+<key>WIRApplicationIdentifierKey</key>
+<string>PID:730</string>
+*/
+rpc_status rpc_recv_applicationUpdated(rpc_t self, const plist_t args) {
+  char *app_id = NULL;
+  char *dest_id = NULL;
+  rpc_status ret;
+  if (!rpc_dict_get_required_string(args, "WIRHostApplicationIdentifierKey", &app_id)) {
+    if (!rpc_dict_get_required_string(args, "WIRApplicationIdentifierKey", &dest_id) &&
+      !self->on_applicationUpdated(self, app_id, dest_id)) {
+      ret = RPC_SUCCESS;
+    } else {
+      ret = RPC_ERROR;
+    }
+  } else if (!rpc_dict_get_required_string(args, "WIRApplicationNameKey", &app_id) &&
+             !rpc_dict_get_required_string(args, "WIRApplicationIdentifierKey", &dest_id) &&
+             !self->on_applicationUpdated(self, app_id, dest_id)) {
+    ret = RPC_SUCCESS;
+  } else {
+    ret = RPC_ERROR;
+  }
+  free(app_id);
+  free(dest_id);
+  return ret;
+}
+
 rpc_status rpc_recv_msg(rpc_t self, const char *selector, const plist_t args) {
   if (!selector) {
     return RPC_ERROR;
@@ -447,6 +499,10 @@ rpc_status rpc_recv_msg(rpc_t self, const char *selector, const plist_t args) {
     }
   } else if (!strcmp(selector, "_rpc_applicationSentData:")) {
     if (!rpc_recv_applicationSentData(self, args)) {
+      return RPC_SUCCESS;
+    }
+  } else if (!strcmp(selector, "_rpc_applicationUpdated:")) {
+    if (!rpc_recv_applicationUpdated(self, args)) {
       return RPC_SUCCESS;
     }
   }


### PR DESCRIPTION
Appium / instruments was sending a new message that wasn't handled
previously, applicationUpdated.  It seems to be changing one PID
to a new PID, so we remove the old PID from the hash table, and
insert the new one.

This is a commit rebased into one for upstream
